### PR TITLE
fix: initialize only the charge payment method

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "format:check": "prettier --check .",
     "lint": "npm run typecheck && npm run format:check && eslint .",
     "lint:fix": "prettier --write . && eslint . --fix",
+    "test": "tsx --test src/auth.test.ts",
     "test:client": "tsx test-client.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Hono } from "hono";
+import { createProtectedRoute } from "./auth";
+import type { AppContext, Env } from "./env";
+
+test("protected routes return an MPP payment challenge", async () => {
+  const app = new Hono<AppContext>();
+  app.use(
+    "/paid",
+    createProtectedRoute({
+      amount: "0.01",
+      description: "Test payment",
+      pattern: "/paid",
+    }),
+  );
+  app.get("/paid", (c) => c.text("paid"));
+
+  const env: Env = {
+    JWT_SECRET: "test-jwt-secret-000000000000000000000000000000000000",
+    MPP_SECRET_KEY: "test-mpp-secret-000000000000000000000000000000000000",
+    PAYMENT_CURRENCY: "0x20c0000000000000000000000000000000000000",
+    PAY_TO: "0x000000000000000000000000000000000000dEaD",
+    PROTECTED_PATTERNS: [
+      {
+        amount: "0.01",
+        description: "Access to premium content for 1 hour",
+        pattern: "/premium/*",
+      },
+    ],
+    TEMPO_TESTNET: true,
+  };
+
+  const response = await app.request("http://localhost/paid", undefined, env);
+
+  assert.equal(response.status, 402);
+  assert.match(
+    response.headers.get("www-authenticate") ?? "",
+    /intent="charge"/,
+  );
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -82,7 +82,7 @@ export function createProtectedRoute(config: ProtectedRouteConfig) {
   return async (c: Context<AppContext>, next: Next) => {
     const mppx = Mppx.create({
       methods: [
-        tempo({
+        tempo.charge({
           currency: c.env.PAYMENT_CURRENCY,
           recipient: c.env.PAY_TO,
           testnet: c.env.TEMPO_TESTNET,


### PR DESCRIPTION
## Summary

- restore `402 Payment Required` responses on protected routes with `mppx@0.4.11`
- initialize only the Tempo charge method used by the proxy
- add a regression test that requires an unpaid protected route to return a charge challenge

## Bug

The stock proxy on `main` returns `500 Internal Server Error` for requests that enter its payment middleware.

`tempo()` creates both `tempo.charge()` and `tempo.session()`. In `mppx@0.4.11`, `tempo.session()` requires a signing account when it is constructed. The proxy supplies `PAY_TO` as a recipient address because it only handles one-time charges, so the unused session constructor throws from `Mppx.create()` before the proxy can check a cookie or return its charge challenge:

```text
Error: tempo.session() requires an `account` ...
    at tempo.session (.../mppx/src/tempo/server/Session.ts:105:11)
    at tempo (.../mppx/src/tempo/server/Methods.ts:17:43)
    at .../src/auth.ts:85:9
```

The proxy has always passed `mppx.charge` to its Hono payment middleware. It does not expose a session handler, channel store, usage-metering configuration, or server signing account. Selecting `tempo.charge()` therefore removes only the unused constructor that causes the failure; it does not remove a supported proxy payment flow.

## Behavior

| Request | Current `main` | This PR |
| --- | --- | --- |
| `GET /__mpp/health` | `200 OK` | `200 OK` |
| Unpaid `GET /__mpp/protected` | `500 Internal Server Error` | `402 Payment Required` with `method="tempo"` and `intent="charge"` |

The public health endpoint does not exercise payment initialization, so it can remain green while protected routes are broken.

## Reproduction

I reproduced this from current `main` at `59ce12a72bad3cd7f331989517a2904d64e0b5d1`:

```sh
npm ci
cp .dev.vars.example .dev.vars
# Set JWT_SECRET and MPP_SECRET_KEY to non-empty local test values.
npm run dev
```

In another terminal:

```sh
curl -i http://localhost:8787/__mpp/health
# HTTP/1.1 200 OK

curl -i http://localhost:8787/__mpp/protected
# HTTP/1.1 500 Internal Server Error
```

Running the same smoke test on this branch returns:

```text
HTTP/1.1 402 Payment Required
WWW-Authenticate: Payment ... method="tempo", intent="charge" ...
```

## Impact

Stock-template builds using the repository lockfile with `mppx@0.4.11` are affected. Previously deployed Worker versions that bundled an older working `mppx` release do not change until they are rebuilt or redeployed.

Unprotected routes and requests bypassed by a Bot Management exception do not enter this constructor and are unaffected.

## Validation

- `npm test`
- `npm run lint`
- exact-main local Wrangler smoke: health `200`, protected route `500` with the session-account error
- PR local Wrangler smoke: health `200`, unpaid protected route `402` with a charge challenge
